### PR TITLE
fix compilation errors on gcc13

### DIFF
--- a/wy.hpp
+++ b/wy.hpp
@@ -13,6 +13,7 @@
 // salted: We use dynamic secret to avoid intended attack.
 
 #include <cassert>
+#include <cstring>
 #include <cstdint>
 #include <vector>
 #include <random>
@@ -426,7 +427,7 @@ namespace wy {
 			using hash_imp::hash_imp;// Inherit constructors
 			inline uint64_t operator()(const STRING_TYPE& elem) const noexcept
 			{
-				return hash_imp::wyhash(reinterpret_cast<const uint8_t*>(elem.data()), sizeof(STRING_TYPE::value_type) * elem.size());
+				return hash_imp::wyhash(reinterpret_cast<const uint8_t*>(elem.data()), sizeof(typename STRING_TYPE::value_type) * elem.size());
 			}
 		};
 	};


### PR DESCRIPTION
There are compilation errors on gcc 13:
```
include/wy.hpp: In function ‘uint64_t wy::internal::_wyr8(const uint8_t*)’:
include/wy.hpp:140:79: error: ‘memcpy’ was not declared in this scope
  140 |         static inline uint64_t _wyr8(const uint8_t* p) noexcept { uint64_t v; memcpy(&v, p, 8); return v; }
      |                                                                               ^~~~~~
include/wy.hpp: In function ‘uint64_t wy::internal::_wyr4(const uint8_t*)’:
include/wy.hpp:141:79: error: ‘memcpy’ was not declared in this scope
  141 |         static inline uint64_t _wyr4(const uint8_t* p) noexcept { uint32_t v; memcpy(&v, p, 4); return v; }
      |                                                                               ^~~~~~
include/wy.hpp: In member function ‘void wy::rand::generate_stream(std::vector<_RealType>&, size_t)’:
include/wy.hpp:309:33: error: there are no arguments to ‘memcpy’ that depend on a template parameter, so a declaration of ‘memcpy’ must be available [-fpermissive]
  309 |                                 memcpy(dataPtr + i * sizeof(uint64_t), &val, sizeof(uint64_t));
      |                                 ^~~~~~
include/wy.hpp: In constructor ‘wy::internal::hash_imp::hash_imp(const uint64_t*)’:
include/wy.hpp:372:33: error: ‘memcpy’ was not declared in this scope
  372 |                                 memcpy(secret, psecret, sizeof(secret));
      |                                 ^~~~~~
include/wy.hpp: In member function ‘uint64_t wy::hash<char*>::operator()(const char*) const’:
include/wy.hpp:497:89: error: ‘strlen’ was not declared in this scope
  497 |                         return hash_imp::wyhash(reinterpret_cast<const uint8_t*>(data), strlen(data));
      |                                                                                         ^~~~~~
include/wy.hpp: In member function ‘uint64_t wy::hash<const char*>::operator()(const char*) const’:
include/wy.hpp:505:89: error: ‘strlen’ was not declared in this scope
  505 |                         return hash_imp::wyhash(reinterpret_cast<const uint8_t*>(data), strlen(data));
      |                                                                                         ^~~~~~
include/wy.hpp: In instantiation of ‘uint64_t wy::internal::hash_string_base<STRING_TYPE>::operator()(const STRING_TYPE&) const [with STRING_TYPE = std::__cxx11::basic_string<char>; uint64_t = long unsigned int]’:
/usr/include/c++/13/bits/hashtable_policy.h:1310:18:   required from ‘std::__detail::_Hash_code_base<_Key, _Value, _ExtractKey, _Hash, _RangeHash, _Unused, __cache_hash_code>::__hash_code std::__detail::_Hash_code_base<_Key, _Value, _ExtractKey, _Hash, _RangeHash, _Unused, __cache_hash_code>::_M_hash_code(const _Key&) const [with _Key = std::__cxx11::basic_string<char>; _Value = std::pair<const std::__cxx11::basic_string<char>, Person>; _ExtractKey = std::__detail::_Select1st; _Hash = wy::hash<std::__cxx11::basic_string<char> >; _RangeHash = std::__detail::_Mod_range_hashing; _Unused = std::__detail::_Default_ranged_hash; bool __cache_hash_code = false; __hash_code = long unsigned int]’
/usr/include/c++/13/bits/hashtable_policy.h:813:45:   required from ‘std::__detail::_Map_base<_Key, std::pair<const _Key, _Val>, _Alloc, std::__detail::_Select1st, _Equal, _Hash, _RangeHash, _Unused, _RehashPolicy, _Traits, true>::mapped_type& std::__detail::_Map_base<_Key, std::pair<const _Key, _Val>, _Alloc, std::__detail::_Select1st, _Equal, _Hash, _RangeHash, _Unused, _RehashPolicy, _Traits, true>::operator[](const key_type&) [with _Key = std::__cxx11::basic_string<char>; _Val = Person; _Alloc = std::allocator<std::pair<const std::__cxx11::basic_string<char>, Person> >; _Equal = std::equal_to<std::__cxx11::basic_string<char> >; _Hash = wy::hash<std::__cxx11::basic_string<char> >; _RangeHash = std::__detail::_Mod_range_hashing; _Unused = std::__detail::_Default_ranged_hash; _RehashPolicy = std::__detail::_Prime_rehash_policy; _Traits = std::__detail::_Hashtable_traits<false, false, true>; mapped_type = Person; key_type = std::__cxx11::basic_string<char>]’
/usr/include/c++/13/bits/unordered_map.h:987:20:   required from ‘std::unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>::mapped_type& std::unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>::operator[](const key_type&) [with _Key = std::__cxx11::basic_string<char>; _Tp = Person; _Hash = wy::hash<std::__cxx11::basic_string<char> >; _Pred = std::equal_to<std::__cxx11::basic_string<char> >; _Alloc = std::allocator<std::pair<const std::__cxx11::basic_string<char>, Person> >; mapped_type = Person; key_type = std::__cxx11::basic_string<char>]’
/home/toge/src/conan-alainesp-wy/all/test_package/test_package.cpp:22:20:   required from here
include/wy.hpp:429:124: error: dependent-name ‘STRING_TYPE::value_type’ is parsed as a non-type, but instantiation yields a type
  429 |                                 return hash_imp::wyhash(reinterpret_cast<const uint8_t*>(elem.data()), sizeof(STRING_TYPE::value_type) * elem.size());
      |                                                                                                              ~~~~~~~~~~~~~~^~
```

This PR try to fix these errors.
